### PR TITLE
AENT-8264: Bump to v2024.04.2+764

### DIFF
--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -4,7 +4,7 @@ echo "+------------------------+"
 echo "| AE5 RStudio Downloader |"
 echo "+------------------------+"
 
-[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2023.12.0-369
+[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2023.12.1-402
 echo "- Target version: ${RSTUDIO_VERSION}"
 
 if [[ -n "$TOOL_PROJECT_URL" && -d data ]]; then

--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -4,7 +4,7 @@ echo "+------------------------+"
 echo "| AE5 RStudio Downloader |"
 echo "+------------------------+"
 
-[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.04.1-764
+[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.04.2-764
 echo "- Target version: ${RSTUDIO_VERSION}"
 
 if [[ -n "$TOOL_PROJECT_URL" && -d data ]]; then

--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -4,7 +4,7 @@ echo "+------------------------+"
 echo "| AE5 RStudio Downloader |"
 echo "+------------------------+"
 
-[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2023.12.1-402
+[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.04.1-748
 echo "- Target version: ${RSTUDIO_VERSION}"
 
 if [[ -n "$TOOL_PROJECT_URL" && -d data ]]; then

--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -4,7 +4,7 @@ echo "+------------------------+"
 echo "| AE5 RStudio Downloader |"
 echo "+------------------------+"
 
-[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.04.1-748
+[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.04.1-764
 echo "- Target version: ${RSTUDIO_VERSION}"
 
 if [[ -n "$TOOL_PROJECT_URL" && -d data ]]; then


### PR DESCRIPTION
Just a simple minor version bump. Tested on Minikube—in fact it helped me discover that I needed to make sure the `~/.cache` directory is properly permissioned.

This cannot be tested yet on Minikube—not until https://github.com/Anaconda-Platform/anaconda-platform/pull/6855 is merged. But once it is:

- Download https://airgap.svc.anaconda.com/misc/rstudio-installer-test.tar.bz2
- Upload into AE5
- Launch a session
- Run `download_rstudio.sh`
- Run `install_rstudio.sh`
- Stop the session
- Switch editor to RStudio
- Launch a new session