### PR TITLE
AENT-8264: bump version to 2024.09.0-375

### DIFF
--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -4,7 +4,7 @@ echo "+------------------------+"
 echo "| AE5 RStudio Downloader |"
 echo "+------------------------+"
 
-[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.04.2-764
+[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.09.0-375
 echo "- Target version: ${RSTUDIO_VERSION}"
 
 if [[ -n "$TOOL_PROJECT_URL" && -d data ]]; then


### PR DESCRIPTION
To test on Minikube:

- Download https://airgap.svc.anaconda.com/misc/rstudio-installer-test.tar.bz2
- Upload this project into your Minikube instance
- Launch a session
- Edit `download_rstudio.sh`. Make sure Line 7 says `RSTUDIO_VERSION=2024.09.0-375`. If it doesn't, change it to that.
- Open a Terminal
- Run `bash download_rstudio.sh`
- Run `bash install_rstudio.sh`
- Stop the session
- Go to Settings
- Change the editor to RStudio
- Launch a new session
- Wait for the editor to come up