### PR TITLE
AENT-8264: Bump to v2024.09.1+394

### DIFF
--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -4,7 +4,7 @@ echo "+------------------------+"
 echo "| AE5 RStudio Downloader |"
 echo "+------------------------+"
 
-[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.09.0-375
+[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.09.1-394
 echo "- Target version: ${RSTUDIO_VERSION}"
 
 if [[ -n "$TOOL_PROJECT_URL" && -d data ]]; then


### PR DESCRIPTION
Just a simple minor version bump.

- Download https://airgap.svc.anaconda.com/misc/rstudio-installer-test.tar.bz2
- Upload into AE5
- Launch a session
- Run `download_rstudio.sh`
- Run `install_rstudio.sh`
- Stop the session
- Switch editor to RStudio
- Launch a new session