### PR TITLE
AENT-8715: Update to v2025.05.0+496

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         source $CONDA/bin/activate
         conda install -y anaconda-project nodejs
         npm install -g mdpdf
-        sed -i.bak -E 's@(extensions:.*)@simpleLineBreaks: false, \1@' $(npm root -g)/mdpdf/src/index.js
+        sed -i.bak -E 's@simpleLineBreaks,@simpleLineBreaks: false,@' $(npm root -g)/mdpdf/dist/src/index.js
         echo ".markdown-body { font-size: 11pt; }" > ../style.css
         mdpdf README.md --format=letter --style=../style.css --gh-style
         mdpdf TOOLS.md --format=letter --style=../style.css --gh-style

--- a/download_rstudio.sh
+++ b/download_rstudio.sh
@@ -4,7 +4,7 @@ echo "+------------------------+"
 echo "| AE5 RStudio Downloader |"
 echo "+------------------------+"
 
-[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2024.12.1-563
+[ $RSTUDIO_VERSION ] || RSTUDIO_VERSION=2025.05.0-496
 echo "- Target version: ${RSTUDIO_VERSION}"
 
 if [[ -n "$TOOL_PROJECT_URL" && -d data ]]; then


### PR DESCRIPTION
v2025.05.0+496

https://airgap.svc.anaconda.com/misc/rstudio-installer-test.tar.bz2

1. Download that project
2. Upload that project into AE5
3. Launch a session
4. `bash download_rstudio.sh && bash install_rstudio.sh`
5. Stop the session
6. Switch to RStudio
7. Launch the session
8. Verify it's working

![Screenshot 2025-05-20 at 10 41 47 AM](https://github.com/user-attachments/assets/5f04d204-a528-4fa0-85dc-f9fb118e2247)